### PR TITLE
Post renderer support

### DIFF
--- a/AlpineTest.Dockerfile
+++ b/AlpineTest.Dockerfile
@@ -21,7 +21,7 @@ ENV HELM_DATA_HOME=/usr/local/share/helm
 
 # Ensure to have latest packages
 RUN apk upgrade --no-cache && \
-    apk add --no-cache --update ca-certificates curl git libc6-compat && \
+    apk add --no-cache --update ca-certificates curl git libc6-compat yq && \
     curl -L ${HELM_BASE_URL}/${HELM_TAR_FILE} |tar xvz && \
     mv ${TARGETOS}-${TARGETARCH}/helm /usr/bin/helm && \
     chmod +x /usr/bin/helm && \
@@ -32,7 +32,7 @@ RUN apk upgrade --no-cache && \
     addgroup -g 1000 -S helmgroup && \
     adduser -u 1000 -S -G helmgroup helmuser
 
-VOLUME ["/apps"] 
+VOLUME ["/apps"]
 
 USER 1000:1000
 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ help:
 
 .PHONY: plugin-dir
 plugin-dir:
-	HELM_3_PLUGINS := $(shell bash -c 'eval $$(helm env); echo $$HELM_PLUGINS')
-	HELM_PLUGIN_DIR := $(HELM_3_PLUGINS)/helm-unittest
+	$(eval HELM_3_PLUGINS := $(shell helm env | grep HELM_PLUGINS | cut -d '=' -f 2 | tr -d '"'))
+	$(eval HELM_PLUGIN_DIR := $(HELM_3_PLUGINS)/helm-unittest)
 
 .PHONY: install
 install: bootstrap build plugin-dir

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build: ## Compile packages and dependencies
 	go build -o untt -ldflags $(LDFLAGS) ./cmd/helm-unittest
 
 .PHONY: build-amd64
-build: ## Compile packages and dependencies
+build: ## Compile packages and dependencies, pinned to amd64 for the docker image
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o untt -ldflags $(LDFLAGS) ./cmd/helm-unittest
 
 .PHONY: dist

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build: ## Compile packages and dependencies
 	go build -o untt -ldflags $(LDFLAGS) ./cmd/helm-unittest
 
 .PHONY: build-amd64
-build: ## Compile packages and dependencies, pinned to amd64 for the docker image
+build-amd64: ## Compile packages and dependencies, pinned to amd64 for the docker image
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o untt -ldflags $(LDFLAGS) ./cmd/helm-unittest
 
 .PHONY: dist

--- a/internal/common/utilities.go
+++ b/internal/common/utilities.go
@@ -84,7 +84,9 @@ func YmlMarshallTestHelper(in interface{}, t *testing.T) string {
 	return string(out)
 }
 
-func SplitBefore(s, sep string) (out []string) {
+func SplitBefore(s, sep string) []string {
+	var out []string
+
 	// this can be omitted if staying analogous with SplitAfter is not a requirement
 	if strings.HasPrefix(s, sep) || s == "" {
 		out = append(out, "")

--- a/internal/common/utilities.go
+++ b/internal/common/utilities.go
@@ -83,3 +83,22 @@ func YmlMarshallTestHelper(in interface{}, t *testing.T) string {
 	assert.NoError(t, err)
 	return string(out)
 }
+
+func SplitBefore(s, sep string) (out []string) {
+	// this can be omitted if staying analogous with SplitAfter is not a requirement
+	if strings.HasPrefix(s, sep) || s == "" {
+		out = append(out, "")
+	}
+
+	for len(s) > 0 {
+		i := strings.Index(s[1:], sep)
+		if i == -1 {
+			out = append(out, s)
+			break
+		}
+
+		out = append(out, s[:i+1])
+		s = s[i+1:]
+	}
+	return out
+}

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithPostRenderer
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithPostRenderer
@@ -1,0 +1,15 @@
+
+### Chart [ with-post-renderer ] ../../test/data/v3/with-post-renderer
+
+
+ PASS  	../../test/data/v3/with-post-renderer/tests/basic_no_postrender_test.yaml
+ PASS  	../../test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 2 passed, 2 total
+Tests:       4 passed, 4 total
+Snapshot:    2 passed, 2 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -34,6 +34,7 @@ func (a *Assertion) Assert(
 	renderError error,
 	result *results.AssertionResult,
 	failfast bool,
+	didPostRender bool,
 ) *results.AssertionResult {
 	result.AssertType = a.AssertType
 	result.Not = a.Not
@@ -41,7 +42,18 @@ func (a *Assertion) Assert(
 	// Ensure assertion is succeeding or failing based on templates to test.
 	assertionPassed := false
 	failInfo := make([]string, 0)
-	selectedDocsByTemplate, indexError := a.selectDocumentsForAssertion(a.getDocumentsByDefaultTemplates(templatesResult))
+
+	var selectedDocsByTemplate map[string][]common.K8sManifest
+	var indexError error
+
+	// If we PostRendered, there's no guarantee the post-renderer will preserve our file mapping.  If it doesn't, the
+	// parser just puts the whole manifest in one "manifest.yaml" so handle that case:
+	if val, ok := templatesResult["manifest.yaml"]; didPostRender && len(templatesResult) == 1 && ok {
+		println("Found non-preserving post-render of manifest.yaml only")
+		selectedDocsByTemplate["manifest.yaml"] = val
+	} else {
+		selectedDocsByTemplate, indexError = a.selectDocumentsForAssertion(a.getDocumentsByDefaultTemplates(templatesResult))
+	}
 	selectedTemplates := a.getKeys(selectedDocsByTemplate)
 
 	// Sort templates to ensure a consistent output
@@ -72,7 +84,9 @@ func (a *Assertion) Assert(
 			rendered, ok := templatesResult[template]
 			var validatePassed bool
 			var singleFailInfo []string
+
 			if !ok && a.requireRenderSuccess {
+
 				noFile := []string{"Error:", a.noFileErrMessage(template)}
 				failInfo = append(failInfo, noFile...)
 				assertionPassed = false

--- a/pkg/unittest/assertion_test.go
+++ b/pkg/unittest/assertion_test.go
@@ -22,7 +22,7 @@ func validateSucceededTestAssertions(
 	a := assert.New(t)
 
 	for idx, assertion := range assertions {
-		result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false)
+		result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: idx}, false, false)
 		a.Equal(&results.AssertionResult{
 			Index:      idx,
 			FailInfo:   []string{},
@@ -334,7 +334,7 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\ttemplate \"not-existed.yaml\" not exists or not selected in test suite"},
@@ -355,7 +355,7 @@ func TestAssertionAssertWhenTemplateNotSpecifiedAndNoDefault(t *testing.T) {
 	common.YmlUnmarshalTestHelper(assertionYAML, &assertion, t)
 
 	a := assert.New(t)
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "\tassertion.template must be given if testsuite.templates is empty"},
@@ -381,7 +381,7 @@ equal:
 
 	a := assert.New(t)
 
-	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false)
+	result := assertion.Assert(renderedMap, fakeSnapshotComparer(true), true, nil, &results.AssertionResult{Index: 0}, false, false)
 	a.Equal(&results.AssertionResult{
 		Index:      0,
 		FailInfo:   []string{"Error:", "document index 1 is out of rage"},

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -236,14 +236,6 @@ func (t *TestJob) RunV3(
 		return result
 	}
 
-	//// use local config if provided, else look to parent
-	//var cfg PostRendererConfig
-	//if t.PostRendererConfig.Cmd != "" {
-	//	cfg = t.PostRendererConfig
-	//} else if postRendererConfig.Cmd != "" {
-	//	cfg = postRendererConfig
-	//}
-
 	outputOfFiles, renderSucceed, renderError := t.renderV3Chart(targetChart, []byte(userValues))
 	writeError := writeRenderedOutput(renderPath, outputOfFiles)
 	if writeError != nil {

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -248,6 +248,8 @@ func (t *TestJob) RunV3(
 		// Continue to enable matching error via failedTemplate assert
 	}
 
+	// TODO:  it looks like chart parsing receives every file (rather than a filtered list based on specified templates)
+	// so we'll need to... pre-filter?
 	postRenderedManifestsOfFiles, didPostRender, err := t.postRender(suitePostRendererConfig, outputOfFiles)
 	if err != nil {
 		result.ExecError = err
@@ -390,10 +392,10 @@ func MergeAndPostRender(renderedManifestsMap map[string]string, postRenderer pos
 	for _, key := range orderedManifests {
 		manifest := renderedManifestsMap[key]
 		renderedManifests.WriteString(yamlFileSeparator + " " + key + "\n")
-		renderedManifests.WriteString(manifest)
+		renderedManifests.WriteString(strings.TrimSpace(manifest) + "\n")
 	}
-
 	var modifiedManifests *bytes.Buffer
+
 	modifiedManifests, err := postRenderer.Run(&renderedManifests)
 	if err != nil {
 		return nil, fmt.Errorf("post-render failed: %w", err)

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1052,6 +1052,8 @@ func Test_SplitManifests(t *testing.T) {
 			},
 		},
 		{
+			// TODO: should we treat the post-renderer handing us an empty file as "a map of one empty file?"
+			// or should we return an empty map?
 			name:  "Empty Input",
 			input: "",
 			expectedManifests: map[string]string{

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1092,7 +1092,6 @@ func Test_SplitManifests(t *testing.T) {
 	}
 }
 
-// TODO:  add a test for what happens when the post-renderer doesn't hand back a file with our comment.
 func Test_MergeAndPostRender(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -85,7 +85,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -116,7 +116,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, renderPath, &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, renderPath, &results.TestJobResult{}, PostRendererConfig{})
 	defer os.RemoveAll(renderPath)
 
 	a := assert.New(t)
@@ -146,7 +146,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -175,7 +175,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -207,7 +207,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -232,7 +232,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -261,7 +261,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, false, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, false, "", &results.TestJobResult{}, PostRendererConfig{})
 	// Write Buffer
 
 	a := assert.New(t)
@@ -291,7 +291,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 	// Write Buffer
 
 	a := assert.New(t)
@@ -318,7 +318,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -350,7 +350,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -377,7 +377,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -399,7 +399,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -423,7 +423,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -449,7 +449,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -475,7 +475,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -497,7 +497,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	a.False(testResult.Passed)
@@ -519,7 +519,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
 	assert.False(t, testResult.Passed)
 	assert.Equal(t, "7", tj.Capabilities.MinorVersion)
 }
@@ -546,7 +546,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -569,7 +569,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -591,7 +591,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -616,7 +616,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
 
@@ -641,7 +641,7 @@ asserts:
 	var tj TestJob
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
@@ -669,7 +669,7 @@ asserts:
 	a := assert.New(t)
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a.Nil(testResult.ExecError)
 	a.True(testResult.Passed)
@@ -691,7 +691,7 @@ asserts:
 	var tj TestJob
 	unmarshalJobTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -812,7 +812,7 @@ asserts:
 	assert := assert.New(t)
 	common.YmlUnmarshalTestHelper(manifest, &tj, t)
 
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	assert.NoError(testResult.ExecError)
 	assert.True(testResult.Passed, testResult.AssertsResult)
@@ -832,7 +832,7 @@ asserts:
 `
 	var tj TestJob
 	common.YmlUnmarshal(manifest, &tj)
-	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	a := assert.New(t)
 
@@ -881,7 +881,7 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -926,7 +926,7 @@ ingress:
 	var tj TestJob
 	unmarshalJobTestHelper(fmt.Sprintf(manifest, file), &tj, t)
 
-	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{})
+	testResult := tj.RunV3(c, nil, true, "", &results.TestJobResult{}, PostRendererConfig{})
 
 	assert.Nil(t, testResult.ExecError)
 	assert.True(t, testResult.Passed)
@@ -962,7 +962,7 @@ func TestV3RunJob_TplFunction_Fail_WithoutAssertion(t *testing.T) {
 	for _, test := range tests {
 		tj := TestJob{}
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 		a.Error(testResult.ExecError)
 		a.False(testResult.Passed)
 		a.EqualError(testResult.ExecError, test.error.Error())
@@ -1008,7 +1008,7 @@ asserts:
 
 	for _, test := range tests {
 		c.Templates = []*v3chart.File{test.template}
-		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{})
+		testResult := tj.RunV3(c, &snapshot.Cache{}, true, "", &results.TestJobResult{}, PostRendererConfig{})
 		assert.Equal(t, test.expected, testResult.Passed)
 		if test.error != nil {
 			assert.NotNil(t, testResult.ExecError)
@@ -1052,9 +1052,11 @@ func Test_SplitManifests(t *testing.T) {
 			},
 		},
 		{
-			name:              "Empty Input",
-			input:             "",
-			expectedManifests: map[string]string{},
+			name:  "Empty Input",
+			input: "",
+			expectedManifests: map[string]string{
+				"manifest.yaml": "",
+			},
 		},
 		{
 			name:  "Manifest with no newline",

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -1070,6 +1070,13 @@ func Test_SplitManifests(t *testing.T) {
 				"test-key": "manifest1\n\n",
 			},
 		},
+		{
+			name:  "Manifest with net-new content",
+			input: "---\nmanifest1\n",
+			expectedManifests: map[string]string{
+				"manifest.yaml": "---\nmanifest1\n",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1081,6 +1088,7 @@ func Test_SplitManifests(t *testing.T) {
 	}
 }
 
+// TODO:  add a test for what happens when the post-renderer doesn't hand back a file with our comment.
 func Test_MergeAndPostRender(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -263,6 +263,17 @@ func TestV3RunnerOkWithFakeK8sClient(t *testing.T) {
 	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
 }
 
+func TestV3RunnerOkWithPostRenderer(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:   printer.NewPrinter(buffer, nil),
+		TestFiles: []string{testTestFiles},
+	}
+	passed := runner.RunV3([]string{testV3WithPostRendererChart})
+	assert.True(t, passed, buffer.String())
+	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
+}
+
 func TestV3RunnerOkWithSchemaValidation(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	runner := TestRunner{

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -224,7 +224,9 @@ type TestSuite struct {
 		APIVersions  []string `yaml:"apiVersions"`
 	}
 	KubernetesProvider KubernetesFakeClientProvider `yaml:"kubernetesProvider"`
-	Tests              []*TestJob                   // TODO:  could every job have its own postRenderer?  that sounds like a schema addition instead of flags.
+	PostRendererConfig PostRendererConfig           `yaml:"postRenderer"`
+
+	Tests []*TestJob
 	// where the test suite file located
 	definitionFile string
 	// route indicate which chart in the dependency hierarchy
@@ -360,7 +362,7 @@ func (s *TestSuite) runV3TestJobs(
 		chart, _ := v3loader.Load(chartPath)
 		log.SetOutput(os.Stdout)
 
-		jobResult := testJob.RunV3(chart, cache, failFast, renderPath, &results.TestJobResult{DisplayName: testJob.Name, Index: idx})
+		jobResult := testJob.RunV3(chart, cache, failFast, renderPath, &results.TestJobResult{DisplayName: testJob.Name, Index: idx}, s.PostRendererConfig)
 		jobResults[idx] = jobResult
 
 		if idx == 0 {

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -224,7 +224,7 @@ type TestSuite struct {
 		APIVersions  []string `yaml:"apiVersions"`
 	}
 	KubernetesProvider KubernetesFakeClientProvider `yaml:"kubernetesProvider"`
-	Tests              []*TestJob
+	Tests              []*TestJob                   // TODO:  could every job have its own postRenderer?  that sounds like a schema addition instead of flags.
 	// where the test suite file located
 	definitionFile string
 	// route indicate which chart in the dependency hierarchy

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -36,6 +36,7 @@ const testV3WithHelmTestsChart string = "../../test/data/v3/with-helm-tests"
 const testV3WitSamenameSubSubChart string = "../../test/data/v3/with-samenamesubsubcharts"
 const testV3WithDocumentSelectorChart string = "../../test/data/v3/with-document-select"
 const testV3WithFakeK8sClientChart string = "../../test/data/v3/with-k8s-fake-client"
+const testV3WithPostRendererChart string = "../../test/data/v3/with-post-renderer"
 
 var tmpdir, _ = os.MkdirTemp("", testSuiteTests)
 

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
@@ -203,6 +204,220 @@ func TestV3RunnerWith_Fixture_Chart_DocumentSelector(t *testing.T) {
 			for _, e := range tt.expected {
 				assert.Contains(t, buffer.String(), e)
 			}
+		})
+	}
+}
+
+func TestSplitBefore(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		separator string
+		expected  []string
+	}{
+		{
+			name:      "Simple Case",
+			input:     "apple-banana-cherry",
+			separator: "-",
+			expected:  []string{"apple", "-banana", "-cherry"}, // Separator at the beginning
+		},
+		{
+			name:      "No Separator",
+			input:     "apple",
+			separator: "-",
+			expected:  []string{"apple"},
+		},
+		{
+			name:      "Separator at Beginning",
+			input:     "-apple-banana",
+			separator: "-",
+			expected:  []string{"", "-apple", "-banana"}, // Separator at the beginning
+		},
+		{
+			name:      "Separator at End",
+			input:     "apple-banana-",
+			separator: "-",
+			expected:  []string{"apple", "-banana", "-"}, // Separator at the beginning
+		},
+		{
+			name:      "Consecutive Separators",
+			input:     "apple--banana",
+			separator: "-",
+			expected:  []string{"apple", "-", "-banana"}, // Separator at the beginning
+		},
+		{
+			name:      "Empty String",
+			input:     "",
+			separator: "-",
+			expected:  []string{""},
+		},
+		{
+			name:      "Special Characters",
+			input:     "one.two.three",
+			separator: ".",
+			expected:  []string{"one", ".two", ".three"},
+		},
+		{
+			name:      "Long Separator",
+			input:     "prefix-one-suffix-two",
+			separator: "-one-",
+			expected:  []string{"prefix", "-one-suffix-two"},
+		},
+		{
+			name:      "Separator and other special characters",
+			input:     "prefix.one-suffix.two",
+			separator: ".",
+			expected:  []string{"prefix", ".one-suffix", ".two"},
+		},
+		{
+			name:      "Complex Case",
+			input:     "part1-part2-SEP-part3-part4-SEP-part5",
+			separator: "SEP",
+			expected:  []string{"part1-part2-", "SEP-part3-part4-", "SEP-part5"},
+		},
+		{
+			name:      "Complex Case with SEP at beginning and end",
+			input:     "SEP-part1-part2-SEP-part3-part4-SEP",
+			separator: "SEP",
+			expected:  []string{"", "SEP-part1-part2-", "SEP-part3-part4-", "SEP"},
+		},
+		{
+			name:      "Another Complex Case",
+			input:     "before#### file: test1\nmanifest1\n#### file: test2\nmanifest2",
+			separator: "#### file:",
+			expected:  []string{"before", "#### file: test1\nmanifest1\n", "#### file: test2\nmanifest2"},
+		},
+		{
+			name:      "Empty Input with Separator at Beginning",
+			input:     "#### file:",
+			separator: "#### file:",
+			expected:  []string{"", "#### file:"},
+		},
+		{
+			name:      "Input with only Separator",
+			input:     "#### file:",
+			separator: "#### file:",
+			expected:  []string{"", "#### file:"},
+		},
+		{
+			name:      "Input with only Separator repeated",
+			input:     "#### file:#### file:",
+			separator: "#### file:",
+			expected:  []string{"", "#### file:", "#### file:"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := common.SplitBefore(test.input, test.separator)
+			assert.Equal(t, test.expected, actual, fmt.Sprintf("Test Case: %s", test.name))
+		})
+	}
+}
+
+func TestSplitAfter(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		separator string
+		expected  []string
+	}{
+		{
+			name:      "Simple Case",
+			input:     "apple-banana-cherry",
+			separator: "-",
+			expected:  []string{"apple-", "banana-", "cherry"},
+		},
+		{
+			name:      "No Separator",
+			input:     "apple",
+			separator: "-",
+			expected:  []string{"apple"},
+		},
+		{
+			name:      "Separator at Beginning",
+			input:     "-apple-banana",
+			separator: "-",
+			expected:  []string{"-", "apple-", "banana"},
+		},
+		{
+			name:      "Separator at End",
+			input:     "apple-banana-",
+			separator: "-",
+			expected:  []string{"apple-", "banana-", ""},
+		},
+		{
+			name:      "Consecutive Separators",
+			input:     "apple--banana",
+			separator: "-",
+			expected:  []string{"apple-", "-", "banana"},
+		},
+		{
+			name:      "Empty String",
+			input:     "",
+			separator: "-",
+			expected:  []string{""},
+		},
+		{
+			name:      "Special Characters",
+			input:     "one.two.three",
+			separator: ".",
+			expected:  []string{"one.", "two.", "three"},
+		},
+		{
+			name:      "Long Separator",
+			input:     "prefix-one-suffix-two",
+			separator: "-one-",
+			expected:  []string{"prefix-one-", "suffix-two"},
+		},
+		{
+			name:      "Separator and other special characters",
+			input:     "prefix.one-suffix.two",
+			separator: ".",
+			expected:  []string{"prefix.", "one-suffix.", "two"},
+		},
+		{
+			name:      "Complex Case",
+			input:     "part1-part2-SEP-part3-part4-SEP-part5",
+			separator: "SEP",
+			expected:  []string{"part1-part2-SEP", "-part3-part4-SEP", "-part5"},
+		},
+		{
+			name:      "Complex Case with SEP at beginning and end",
+			input:     "SEP-part1-part2-SEP-part3-part4-SEP",
+			separator: "SEP",
+			expected:  []string{"SEP", "-part1-part2-SEP", "-part3-part4-SEP", ""},
+		},
+		{
+			name:      "Another Complex Case",
+			input:     "before#### file: test1\nmanifest1\n#### file: test2\nmanifest2",
+			separator: "#### file:",
+			expected:  []string{"before#### file:", " test1\nmanifest1\n#### file:", " test2\nmanifest2"},
+		},
+		{
+			name:      "Empty Input with Separator at Beginning",
+			input:     "#### file:",
+			separator: "#### file:",
+			expected:  []string{"#### file:", ""},
+		},
+		{
+			name:      "Input with only Separator",
+			input:     "#### file:",
+			separator: "#### file:",
+			expected:  []string{"#### file:", ""},
+		},
+		{
+			name:      "Input with only Separator repeated",
+			input:     "#### file:#### file:",
+			separator: "#### file:",
+			expected:  []string{"#### file:", "#### file:", ""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := strings.SplitAfter(test.input, test.separator)
+			assert.Equal(t, test.expected, actual, fmt.Sprintf("Test Case: %s", test.name))
 		})
 	}
 }

--- a/pkg/unittest/utils_test.go
+++ b/pkg/unittest/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/helm-unittest/helm-unittest/internal/common"
@@ -215,6 +214,7 @@ func TestSplitBefore(t *testing.T) {
 		separator string
 		expected  []string
 	}{
+		// This suite was constructed against a test suite for SplitAfter (to check for parity).
 		{
 			name:      "Simple Case",
 			input:     "apple-banana-cherry",
@@ -310,113 +310,6 @@ func TestSplitBefore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := common.SplitBefore(test.input, test.separator)
-			assert.Equal(t, test.expected, actual, fmt.Sprintf("Test Case: %s", test.name))
-		})
-	}
-}
-
-func TestSplitAfter(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     string
-		separator string
-		expected  []string
-	}{
-		{
-			name:      "Simple Case",
-			input:     "apple-banana-cherry",
-			separator: "-",
-			expected:  []string{"apple-", "banana-", "cherry"},
-		},
-		{
-			name:      "No Separator",
-			input:     "apple",
-			separator: "-",
-			expected:  []string{"apple"},
-		},
-		{
-			name:      "Separator at Beginning",
-			input:     "-apple-banana",
-			separator: "-",
-			expected:  []string{"-", "apple-", "banana"},
-		},
-		{
-			name:      "Separator at End",
-			input:     "apple-banana-",
-			separator: "-",
-			expected:  []string{"apple-", "banana-", ""},
-		},
-		{
-			name:      "Consecutive Separators",
-			input:     "apple--banana",
-			separator: "-",
-			expected:  []string{"apple-", "-", "banana"},
-		},
-		{
-			name:      "Empty String",
-			input:     "",
-			separator: "-",
-			expected:  []string{""},
-		},
-		{
-			name:      "Special Characters",
-			input:     "one.two.three",
-			separator: ".",
-			expected:  []string{"one.", "two.", "three"},
-		},
-		{
-			name:      "Long Separator",
-			input:     "prefix-one-suffix-two",
-			separator: "-one-",
-			expected:  []string{"prefix-one-", "suffix-two"},
-		},
-		{
-			name:      "Separator and other special characters",
-			input:     "prefix.one-suffix.two",
-			separator: ".",
-			expected:  []string{"prefix.", "one-suffix.", "two"},
-		},
-		{
-			name:      "Complex Case",
-			input:     "part1-part2-SEP-part3-part4-SEP-part5",
-			separator: "SEP",
-			expected:  []string{"part1-part2-SEP", "-part3-part4-SEP", "-part5"},
-		},
-		{
-			name:      "Complex Case with SEP at beginning and end",
-			input:     "SEP-part1-part2-SEP-part3-part4-SEP",
-			separator: "SEP",
-			expected:  []string{"SEP", "-part1-part2-SEP", "-part3-part4-SEP", ""},
-		},
-		{
-			name:      "Another Complex Case",
-			input:     "before#### file: test1\nmanifest1\n#### file: test2\nmanifest2",
-			separator: "#### file:",
-			expected:  []string{"before#### file:", " test1\nmanifest1\n#### file:", " test2\nmanifest2"},
-		},
-		{
-			name:      "Empty Input with Separator at Beginning",
-			input:     "#### file:",
-			separator: "#### file:",
-			expected:  []string{"#### file:", ""},
-		},
-		{
-			name:      "Input with only Separator",
-			input:     "#### file:",
-			separator: "#### file:",
-			expected:  []string{"#### file:", ""},
-		},
-		{
-			name:      "Input with only Separator repeated",
-			input:     "#### file:#### file:",
-			separator: "#### file:",
-			expected:  []string{"#### file:", "#### file:", ""},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := strings.SplitAfter(test.input, test.separator)
 			assert.Equal(t, test.expected, actual, fmt.Sprintf("Test Case: %s", test.name))
 		})
 	}

--- a/plugin-dbg.yaml
+++ b/plugin-dbg.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "0.7.2"
+version: "0.8.0"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "0.7.2"
+version: "0.8.0"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false

--- a/test/data/v3/with-post-renderer/.helmignore
+++ b/test/data/v3/with-post-renderer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/test/data/v3/with-post-renderer/Chart.yaml
+++ b/test/data/v3/with-post-renderer/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: with-post-renderer
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/test/data/v3/with-post-renderer/templates/basic.yaml
+++ b/test/data/v3/with-post-renderer/templates/basic.yaml
@@ -1,0 +1,4 @@
+---
+metadata:
+  annotations:
+    foo: "bar"

--- a/test/data/v3/with-post-renderer/tests/__snapshot__/basic_no_postrender_test.yaml.snap
+++ b/test/data/v3/with-post-renderer/tests/__snapshot__/basic_no_postrender_test.yaml.snap
@@ -1,0 +1,5 @@
+manifest should match snapshot:
+  1: |
+    metadata:
+      annotations:
+        foo: bar

--- a/test/data/v3/with-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
+++ b/test/data/v3/with-post-renderer/tests/__snapshot__/basic_postrender_test.yaml.snap
@@ -1,0 +1,6 @@
+manifest should match snapshot:
+  1: |
+    metadata:
+      annotations:
+        appended: new
+        foo: bar

--- a/test/data/v3/with-post-renderer/tests/basic_no_postrender_test.yaml
+++ b/test/data/v3/with-post-renderer/tests/basic_no_postrender_test.yaml
@@ -1,0 +1,11 @@
+templates:
+  - templates/basic.yaml
+tests:
+  - it: manifest should match snapshot
+    asserts:
+      - matchSnapshot: {}
+      - notExists:
+          path: metadata.annotations.appended
+      - equal:
+          path: metadata.annotations.foo
+          value: bar

--- a/test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
+++ b/test/data/v3/with-post-renderer/tests/basic_postrender_test.yaml
@@ -1,0 +1,34 @@
+templates:
+  - templates/basic.yaml
+postRenderer:
+  cmd: "yq"
+  args:
+    - "eval"
+    - '.metadata.annotations.appended="new"'
+    - "-"
+tests:
+  - it: manifest should match snapshot
+    asserts:
+      - matchSnapshot: {}
+  - it: manifest should include an extra annotation due to suite yq post-renderer
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.annotations.appended
+          value: new
+  - it: manifest should overwrite existing annotation due to test-job yq post-renderer
+    postRenderer:
+      cmd: "yq"
+      args:
+        - "eval"
+        - '.metadata.annotations.foo="baz"'
+        - "-"
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: baz
+      # never added by the suite yq because it was overridden in the job
+      - notExists:
+          path: metadata.annotations.appended


### PR DESCRIPTION
Adds post-renderer support per the helm `--post-renderer` contract (which expects a series of manifests on stdin and returns manifests on stdout).

Support is added at the test suite level and at the individual test level.

The tests for this functionality now have a dependency on `yq` (since that's the simplest post-renderer I could think to test with).

We try our best to preserve filename mapping out -> in, which is successful in the event that our manifest post-renderer retains comments.  If it doesn't, we punt, and call the returned manifest `manifest.yaml` as a single file containing all the returned yaml documents.  

Included:
* the intended functional changes
* unit tests for the post-renderer
* a new integration test suite that validates `yq` is able to transform manifests prior to assertion

Unknowns:
* what should we do if the post-renderer fails (e.g., `yq` doesn't exist)?
  * should this be a category of error, or do we consider it an environment problem and punt?
* is our best-effort handling of the returned info from the post-renderer (a single file called `manifest.yaml`) acceptable?
  * there is a known edge case if your `post-renderer` creates net-new manifests and returns them alongside modified manifests which *do* preserve the file separator comments; they will be parsed in the order received as belonging to the currently-open file
* how does this project handle version updating?  is there a tool we need to run?  a file to update?
  * I have updated plugin.yaml but I'm not sure if the PR creator should be declaring the new version increment
* how is the json schema updated for validation?